### PR TITLE
Update runbpm.js

### DIFF
--- a/docs/js/runbpm.js
+++ b/docs/js/runbpm.js
@@ -2,7 +2,7 @@ var map = L.map("map").fitWorld();
 var started = false;
 var lastlatlng = {};
 
-var tiles = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+var tiles = L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
   maxZoom: 19,
   attribution:
     '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',


### PR DESCRIPTION
`{s}.` is no longer recommended now that we support HTTP/2 + HTTP/3.